### PR TITLE
Tweak border styles and add inlay for empty slots

### DIFF
--- a/src/components/EmptyCharacterSheetSlot/index.tsx
+++ b/src/components/EmptyCharacterSheetSlot/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useMemo, useState } from "react";
-import CharacterSheetSlot from "../BaseCharacterSheetSlot";
+import styled from "styled-components";
+import BaseCharacterSheetSlot from "../BaseCharacterSheetSlot";
 import useFlipFlop from "../useFlipFlop";
 import { GameContext } from "../GameProvider";
 import { CardSlotMetadata, UniqueCardName } from "../../types";
@@ -61,6 +62,10 @@ const EmptyCharacterSheetSlot = (props: Props) => {
     </>
   );
 };
+
+const CharacterSheetSlot = styled(BaseCharacterSheetSlot)`
+  box-shadow: inset 0.1em 0.1em 0.1em 0 rgba(0, 0, 0, 0.2), inset -0.1em -0.1em 0.1em 0 rgba(255, 255, 255, 0.2);
+`;
 
 // could be cleaner and better leverage styled components, but as of the
 // time of writing the design is still up in the air, so not investing in that

--- a/src/components/EquippedCharacterSheetSlot/index.tsx
+++ b/src/components/EquippedCharacterSheetSlot/index.tsx
@@ -71,7 +71,7 @@ const EquippedCharacterSheetSlot = (props: Props) => {
 };
 
 const CharacterSheetSlot = styled(BaseCharacterSheetSlot)`
-  box-shadow: inset 0.1em 0.1em 0.1em 0 rgba(255, 255, 255, 0.5), inset -0.1em -0.1em 0.1em 0 rgba(0, 0, 0, 0.5);
+  box-shadow: inset 0.1em 0.1em 0.1em 0 rgba(255, 255, 255, 0.2), inset -0.1em -0.1em 0.1em 0 rgba(0, 0, 0, 0.2);
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
Add styles for empty slots, trying to make them look like there's a hollow/groove.

<img width="380" alt="empty" src="https://user-images.githubusercontent.com/3261681/169943532-da72e74f-5577-486a-b7d4-057cfce16e3d.png">
<img width="377" alt="mixed" src="https://user-images.githubusercontent.com/3261681/169943551-b2101479-12ce-48ab-b56f-0996533aeb7f.png">

